### PR TITLE
Fix storing user and pass in client cfg

### DIFF
--- a/src/game/client/library/swgClientUserInterface/src/shared/page/SwgCuiLoginScreen.cpp
+++ b/src/game/client/library/swgClientUserInterface/src/shared/page/SwgCuiLoginScreen.cpp
@@ -85,12 +85,19 @@ m_connecting      (false)
 	}
 	else
 	{
-		m_passwordTextbox->SetLocalText (Unicode::emptyString);
+		if (ConfigClientGame::getLoginClientID()) {
+			m_usernameTextbox->SetLocalText(Unicode::narrowToWide(ConfigClientGame::getLoginClientID()));
+		}
+		else {
+			m_usernameTextbox->SetLocalText(Unicode::emptyString);
+		}
 
-		if (ConfigClientGame::getLoginClientID ())
-			m_usernameTextbox->SetLocalText (Unicode::narrowToWide (ConfigClientGame::getLoginClientID ()));
-		else
-			m_usernameTextbox->SetLocalText (Unicode::emptyString);
+		if (ConfigClientGame::getLoginClientPassword()) {
+			m_passwordTextbox->SetLocalText(Unicode::narrowToWide(ConfigClientGame::getLoginClientPassword()));
+		}
+		else {
+			m_passwordTextbox->SetLocalText(Unicode::emptyString);
+		}
 	}
 
 	DEBUG_REPORT_LOG_PRINT (true, ("SwgCuiLoginScreen: username=%s, sessionId=%s\n", ConfigClientGame::getLoginClientID (), sessionId ? sessionId : "null"));

--- a/src/game/server/application/SwgConversationEditor/src/win32/SwgConversationEditorDoc.cpp
+++ b/src/game/server/application/SwgConversationEditor/src/win32/SwgConversationEditorDoc.cpp
@@ -2407,8 +2407,8 @@ bool SwgConversationEditorDoc::writeScript (CString const & scriptName, CString 
 		{
 			outfile.WriteString ("public int OnNpcConversationResponse(obj_id self, String conversationId, obj_id player, string_id response) throws InterruptedException\n{\n");
 
-			//	if (conversationId != <conversationId>)
-			buffer.Format ("\tif (conversationId != \"%s\")\n", fileName);
+			//	if (!conversationId.equals(<conversationId>))
+			buffer.Format ("\tif (!conversationId.equals(\"%s\"))\n", fileName);
 			outfile.WriteString (buffer);
 
 			//		return SCRIPT_CONTINUE;

--- a/src/game/server/application/SwgConversationEditor/src/win32/SwgConversationEditorDoc.cpp
+++ b/src/game/server/application/SwgConversationEditor/src/win32/SwgConversationEditorDoc.cpp
@@ -2285,7 +2285,7 @@ bool SwgConversationEditorDoc::writeScript (CString const & scriptName, CString 
 					if (numberOfResponses > 0)
 					{
 						// int *_handleBranch<n> (obj_id player, obj_id npc, string_id response)
-						buffer.Format("int %s_handleBranch%i (obj_id player, obj_id npc, string_id response)\n", fileName, sourceBranch->getBranchId());
+						buffer.Format("int %s_handleBranch%i (obj_id player, obj_id npc, string_id response) throws InterruptedException\n", fileName, sourceBranch->getBranchId());
 						outfile.WriteString(buffer);
 
 						// {
@@ -2314,7 +2314,7 @@ bool SwgConversationEditorDoc::writeScript (CString const & scriptName, CString 
 							outfile.WriteString (buffer);
 
 							//	if (response == "<responseTextCrc>")
-							buffer.Format("\tif (response == \"s_%s\")\n", response->getStringId().c_str());
+							buffer.Format("\tif (response.equals(\"s_%s\"))\n", response->getStringId().c_str());
 							outfile.WriteString (buffer);
 	
 							//	{
@@ -2371,7 +2371,7 @@ bool SwgConversationEditorDoc::writeScript (CString const & scriptName, CString 
 		outfile.WriteString (cs_scriptTriggerDelimiter);
 		{
 			outfile.WriteString ("//-- This function should move to base_class.java\n");
-			outfile.WriteString ("boolean npcStartConversation(obj_id player, obj_id npc, string convoName, string_id greetingId, prose_package greetingProse, string_id[] responses)\n");
+			outfile.WriteString ("boolean npcStartConversation(obj_id player, obj_id npc, String convoName, string_id greetingId, prose_package greetingProse, string_id[] responses)\n");
 			outfile.WriteString ("{\n");
 			outfile.WriteString ("\tObject[] objects = new Object[responses.length];\n");
 			outfile.WriteString ("\tSystem.arraycopy(responses, 0, objects, 0, responses.length);\n");


### PR DESCRIPTION
This enables the ability to store your account credentials locally thereby enabling auto-login so you don't have to type in your username or password every time you launch the client and instead you land directly on the character creation screen.

I imagine this was removed when SOE enabled sessions from the station launchpad but don't see any reason for it to not exist now.

The following goes in your client-side cfg for this to work:
```ini
loginClientID=username
loginClientPassword=yourpassword
autoConnectToLoginServer=true
```