### PR TITLE
GU 16.9 - No Trade Removable

### DIFF
--- a/src/engine/client/library/clientGame/src/shared/core/ObjectAttributeManager.cpp
+++ b/src/engine/client/library/clientGame/src/shared/core/ObjectAttributeManager.cpp
@@ -91,6 +91,7 @@ namespace ObjectAttributeManagerNamespace
 		bool hasTooltips;
 		bool noTrade;
 		bool noTradeShared;
+		bool noTradeRemovable;
 		int revision;
 		int tier;
 		bool unique;
@@ -102,6 +103,7 @@ namespace ObjectAttributeManagerNamespace
 		hasTooltips(false),
 		noTrade(false),
 		noTradeShared(false),
+		noTradeRemovable(false),
 		revision(_revision),
 		tier(-1),
 		unique(false),
@@ -119,6 +121,9 @@ namespace ObjectAttributeManagerNamespace
 
 				if (attribPair.first.find(SharedObjectAttributes::no_trade_shared) != std::string::npos)
 					noTradeShared = true;
+
+				if (attribPair.first.find(SharedObjectAttributes::no_trade_removable) != std::string::npos)
+					noTradeRemovable = true;
 
 				if (attribPair.first.find(SharedObjectAttributes::unique) != std::string::npos)
 					unique = true;
@@ -635,6 +640,9 @@ void ObjectAttributeManager::formatAttributes   (const AttributeVector & av, Uni
 			continue;
 
 		if (fullKey.find(SharedObjectAttributes::no_trade_shared) != std::string::npos)
+			continue;
+
+		if (fullKey.find(SharedObjectAttributes::no_trade_removable) != std::string::npos)
 			continue;
 
 		if (fullKey.find(SharedObjectAttributes::unique) != std::string::npos)
@@ -1367,6 +1375,22 @@ bool ObjectAttributeManager::isNoTradeShared(std::string const & staticItemName)
 	}
 
 	return noTradeShared;
+}
+
+//----------------------------------------------------------------------
+
+bool ObjectAttributeManager::isNoTradeRemovable(NetworkId const & id)
+{
+	bool noTradeRemovable = false;
+
+	AttributeMap::const_iterator it = s_attribs.find(id);
+	if (it != s_attribs.end())
+	{
+		AttributeInfo const & info = it->second;
+		noTradeShared = info.noTradeRemovable;
+	}
+
+	return noTradeRemovable;
 }
 
 //----------------------------------------------------------------------

--- a/src/engine/client/library/clientGame/src/shared/core/ObjectAttributeManager.h
+++ b/src/engine/client/library/clientGame/src/shared/core/ObjectAttributeManager.h
@@ -86,6 +86,7 @@ public:
 	static bool isNoTrade(std::string const & staticItemName);
 	static bool isNoTradeShared(NetworkId const & id);
 	static bool isNoTradeShared(std::string const & staticItemName);
+	static bool isNoTradeRemovable(NetworkId const & id);
 	// unique stuff
 	static bool isUnique(NetworkId const & id);
 	static bool isUnique(std::string const & staticItemName);

--- a/src/engine/client/library/clientUserInterface/src/shared/core/CuiStringIds.h
+++ b/src/engine/client/library/clientUserInterface/src/shared/core/CuiStringIds.h
@@ -184,6 +184,7 @@ namespace CuiStringIds
 
 	MAKE_STRING_ID(ui,      no_trade_tooltip);
 	MAKE_STRING_ID(ui,      no_trade_shared_tooltip);
+	MAKE_STRING_ID(ui,      no_trade_removable_tooltip);
 	MAKE_STRING_ID(ui,      unique_tooltip);
 
 	MAKE_STRING_ID(ui,      change_friend_without_saving);

--- a/src/game/client/library/swgClientUserInterface/src/shared/page/SwgCuiInventoryInfo.cpp
+++ b/src/game/client/library/swgClientUserInterface/src/shared/page/SwgCuiInventoryInfo.cpp
@@ -732,7 +732,12 @@ void SwgCuiInventoryInfo::updateAttributeFlags()
 
 		if (isNoTradeVisible)
 		{
-			if (ObjectAttributeManager::isNoTradeShared(object->getNetworkId()))
+			if (ObjectAttributeManager::isNoTradeRemovable(object->getNetworkId()))
+			{
+				m_noTrade->SetLocalText(StringId("object_usability", "no_trade_removable").localize());
+				m_noTrade->SetTooltip(CuiStringIds::no_trade_shared_removable.localize());
+			}
+			else if (ObjectAttributeManager::isNoTradeShared(object->getNetworkId()))
 			{
 				m_noTrade->SetLocalText(StringId("object_usability", "no_trade_shared").localize());
 				m_noTrade->SetTooltip(CuiStringIds::no_trade_shared_tooltip.localize());


### PR DESCRIPTION
Summary: Adds support for the "No Trade Removable" badge at the top right of the details pane on items.

See https://github.com/SWG-Source/dsrc/pull/151 for full details on this change.

**Warning**: I haven't been able to test this locally, as I haven't got the client build working - so this PR is a massive assumption that it will work. Given this PR is not essential for the functionality of the rest of the changeset, I'd hold off on merging it until someone who can compile the client can test it.