### PR TITLE
Added feature to use entertainer captcha percent from the server config

### DIFF
--- a/src/engine/client/library/clientGame/src/shared/network/GameNetwork.cpp
+++ b/src/engine/client/library/clientGame/src/shared/network/GameNetwork.cpp
@@ -267,7 +267,8 @@ m_userPort                   (0),
 m_acceptSceneCommand         (false),
 m_stationId                  (static_cast<StationId>(ConfigFile::getKeyInt("Station", "stationId", 0))),
 m_taskConnection             (0),
-m_weatherUpdateInterval      (0)
+m_weatherUpdateInterval      (0),
+m_entertainerCaptchaPercent  (40)
 {
 	uint16 taskConnectionPort = ConfigClientGame::getTaskConnectionPort();
 	if(taskConnectionPort)
@@ -687,6 +688,7 @@ void GameNetwork::receiveParametersMessage (const ParametersMessage & msg)
 {
 	DEBUG_FATAL(s_instance == 0, ("GameNetwork not installed"));
 	m_weatherUpdateInterval = msg.getWeatherUpdateInterval();
+	m_entertainerCaptchaPercent = msg.getEntertainerCaptchaPercent();
 }
 
 //----------------------------------------------------------------------
@@ -856,6 +858,14 @@ int GameNetwork::getWeatherUpdateInterval()
 {
 	DEBUG_FATAL(s_instance == 0, ("GameNetwork not installed"));
 	return s_instance->m_weatherUpdateInterval;
+}
+
+//-------------------------------------------------------------------
+
+int GameNetwork::getEntertainerCaptchaPercent()
+{
+	DEBUG_FATAL(s_instance == 0, ("GameNetwork not installed"));
+	return s_instance->m_entertainerCaptchaPercent;
 }
 
 //-------------------------------------------------------------------

--- a/src/engine/client/library/clientGame/src/shared/network/GameNetwork.h
+++ b/src/engine/client/library/clientGame/src/shared/network/GameNetwork.h
@@ -110,6 +110,7 @@ public:
 	static void                        setAcceptSceneCommand   (bool b);
 
 	static int                         getWeatherUpdateInterval();
+	static int                         getEntertainerCaptchaPercent();
 
 	static void                        updateServerWithJediSlotInfo();
 
@@ -153,6 +154,7 @@ private:
 	StationId                m_stationId;
 	TaskConnection *         m_taskConnection;
 	int                      m_weatherUpdateInterval;
+	int                      m_entertainerCaptchaPercent;
 };
 
 //-------------------------------------------------------------------

--- a/src/engine/shared/library/sharedNetworkMessages/src/shared/clientGameServer/ParametersMessage.cpp
+++ b/src/engine/shared/library/sharedNetworkMessages/src/shared/clientGameServer/ParametersMessage.cpp
@@ -10,22 +10,34 @@
 
 // ======================================================================
 
-ParametersMessage::ParametersMessage(int weatherUpdateInterval) :
+ParametersMessage::ParametersMessage(int weatherUpdateInterval, int entertainerCaptchaPercent) :
 		GameNetworkMessage("ParametersMessage"),
-		m_weatherUpdateInterval(weatherUpdateInterval)
+		m_weatherUpdateInterval(weatherUpdateInterval),
+		m_entertainerCaptchaPercent(entertainerCaptchaPercent)
 {
 	addVariable(m_weatherUpdateInterval);
+	addVariable(m_entertainerCaptchaPercent);
 }
 
 //-----------------------------------------------------------------------
 
 ParametersMessage::ParametersMessage(Archive::ReadIterator & source) :
 		GameNetworkMessage("ParametersMessage"),
-		m_weatherUpdateInterval()
+		m_weatherUpdateInterval(),
+		m_entertainerCaptchaPercent(40)
 {
 	addVariable(m_weatherUpdateInterval);
+	addVariable(m_entertainerCaptchaPercent);
 
-	unpack(source);
+	unsigned short packedSize = 0;
+	Archive::get(source, packedSize);
+
+	unsigned short unpackedSize = 0;
+	std::vector<Archive::AutoVariableBase *>::iterator i;
+	for(i = members.begin(); i != members.end() && unpackedSize < packedSize; ++i, ++unpackedSize)
+	{
+		(*i)->unpack(source);
+	}
 }
 
 // ----------------------------------------------------------------------

--- a/src/engine/shared/library/sharedNetworkMessages/src/shared/clientGameServer/ParametersMessage.h
+++ b/src/engine/shared/library/sharedNetworkMessages/src/shared/clientGameServer/ParametersMessage.h
@@ -31,15 +31,17 @@
 class ParametersMessage : public GameNetworkMessage
 {
   public:
-	ParametersMessage(int weatherUpdateInterval);
+	ParametersMessage(int weatherUpdateInterval, int entertainerCaptchaPercent = 40);
 	explicit ParametersMessage(Archive::ReadIterator & source);
 	virtual ~ParametersMessage();
 
   public:
 	int getWeatherUpdateInterval() const;
+	int getEntertainerCaptchaPercent() const;
 	
   private:
 	Archive::AutoVariable<int> m_weatherUpdateInterval;
+	Archive::AutoVariable<int> m_entertainerCaptchaPercent;
 
 	ParametersMessage();
 	ParametersMessage(const ParametersMessage&);
@@ -51,6 +53,13 @@ class ParametersMessage : public GameNetworkMessage
 inline int ParametersMessage::getWeatherUpdateInterval() const
 {
 	return m_weatherUpdateInterval.get();
+}
+
+// ----------------------------------------------------------------------
+
+inline int ParametersMessage::getEntertainerCaptchaPercent() const
+{
+	return m_entertainerCaptchaPercent.get();
 }
 
 // ======================================================================

--- a/src/game/client/library/swgClientUserInterface/src/shared/page/SwgCuiBuffBuilderBuffer.cpp
+++ b/src/game/client/library/swgClientUserInterface/src/shared/page/SwgCuiBuffBuilderBuffer.cpp
@@ -11,6 +11,7 @@
 #include "clientGame/ClientExpertiseManager.h"
 #include "clientGame/CreatureObject.h"
 #include "clientGame/Game.h"
+#include "clientGame/GameNetwork.h"
 #include "clientGame/ProsePackageManagerClient.h"
 #include "clientUserInterface/CuiManager.h"
 #include "clientUserInterface/CuiMessageBox.h"
@@ -206,7 +207,7 @@ void SwgCuiBuffBuilderBuffer::OnButtonPressed( UIWidget *context )
 	//send the update packet
 	else if(context == m_acceptButton)
 	{
-		if(m_failedLastVerification || Random::random(1, 5) <= 2) // 40% chance
+		if(m_failedLastVerification || Random::random(1, 100) <= GameNetwork::getEntertainerCaptchaPercent())
 		{
 			CuiStringVariablesData csvd;
 			Object const * sourceObj = Game::getPlayer();


### PR DESCRIPTION
Added a server-side parameter to control the entertainer captcha percent on the client.

The default remains 40. To disable the entertainer captcha, set the value to zero:

[GameServer]
entertainerCaptchaPercent=0